### PR TITLE
Add CLI tool for Go module dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # colab
 Code Lab for automated refactoring and updates
+
+## CLI Tool for Go Module Dependency Updates
+
+This repository includes a CLI tool written in Rust that scans all Go code and replaces module dependency references as specified in a YAML file. The tool uses tree-sitter for language parsing.
+
+### Usage
+
+1. Ensure you have Rust installed on your system. If not, you can install it from [rust-lang.org](https://www.rust-lang.org/).
+
+2. Clone this repository and navigate to the `cli` directory:
+
+   ```sh
+   git clone https://github.com/grahambrooks/colab.git
+   cd colab/cli
+   ```
+
+3. Build the CLI tool:
+
+   ```sh
+   cargo build --release
+   ```
+
+4. Create a `config.yaml` file in the `cli` directory with the following structure:
+
+   ```yaml
+   replace:
+       go-module:
+           from: some.module
+           to: another.module
+   ```
+
+5. Run the CLI tool:
+
+   ```sh
+   ./target/release/cli --config config.yaml --path /path/to/go/code
+   ```
+
+   Replace `/path/to/go/code` with the path to the directory containing your Go code.
+
+The CLI tool will scan all Go files in the specified directory and replace module dependency references as specified in the `config.yaml` file.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cli"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+clap = "2.33.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"
+tree-sitter = "0.19.0"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,76 @@
+use serde::{Deserialize, Serialize};
+use serde_yaml;
+use std::fs;
+use std::path::Path;
+use tree_sitter::{Language, Parser};
+
+extern "C" {
+    fn tree_sitter_go() -> Language;
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Config {
+    replace: Replace,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Replace {
+    #[serde(rename = "go-module")]
+    go_module: GoModule,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct GoModule {
+    from: String,
+    to: String,
+}
+
+pub fn read_config<P: AsRef<Path>>(path: P) -> Result<Config, Box<dyn std::error::Error>> {
+    let file = fs::File::open(path)?;
+    let config: Config = serde_yaml::from_reader(file)?;
+    Ok(config)
+}
+
+pub fn process_directory(parser: &Parser, config: &Config, path: &Path) {
+    if path.is_dir() {
+        for entry in fs::read_dir(path).expect("Failed to read directory") {
+            let entry = entry.expect("Failed to read directory entry");
+            let path = entry.path();
+            if path.is_dir() {
+                process_directory(parser, config, &path);
+            } else if path.extension().and_then(|s| s.to_str()) == Some("go") {
+                process_file(parser, config, &path);
+            }
+        }
+    }
+}
+
+pub fn process_file(parser: &Parser, config: &Config, path: &Path) {
+    let source_code = fs::read_to_string(path).expect("Failed to read file");
+    let tree = parser.parse(&source_code, None).expect("Failed to parse file");
+
+    let mut cursor = tree.walk();
+    let mut edits = Vec::new();
+
+    loop {
+        let node = cursor.node();
+        if node.is_named() && node.kind() == "import_spec" {
+            let module_name = node.utf8_text(source_code.as_bytes()).expect("Failed to get text");
+            if module_name.contains(&config.replace.go_module.from) {
+                let new_module_name = module_name.replace(&config.replace.go_module.from, &config.replace.go_module.to);
+                edits.push((node.start_byte(), node.end_byte(), new_module_name));
+            }
+        }
+
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+    }
+
+    let mut new_source_code = source_code.clone();
+    for (start, end, replacement) in edits.iter().rev() {
+        new_source_code.replace_range(*start..*end, replacement);
+    }
+
+    fs::write(path, new_source_code).expect("Failed to write file");
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,112 @@
+use clap::{App, Arg};
+use serde::{Deserialize, Serialize};
+use serde_yaml;
+use std::fs;
+use std::path::Path;
+use tree_sitter::{Language, Parser};
+
+extern "C" {
+    fn tree_sitter_go() -> Language;
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Config {
+    replace: Replace,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Replace {
+    #[serde(rename = "go-module")]
+    go_module: GoModule,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct GoModule {
+    from: String,
+    to: String,
+}
+
+fn main() {
+    let matches = App::new("Go Module Dependency Updater")
+        .version("1.0")
+        .author("Your Name <your.email@example.com>")
+        .about("Scans Go code and replaces module dependency references as specified in a YAML file")
+        .arg(
+            Arg::with_name("config")
+                .short("c")
+                .long("config")
+                .value_name("FILE")
+                .help("Sets a custom config file")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("path")
+                .short("p")
+                .long("path")
+                .value_name("PATH")
+                .help("Sets the path to the directory containing Go code")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let config_path = matches.value_of("config").unwrap_or("config.yaml");
+    let code_path = matches.value_of("path").unwrap_or(".");
+
+    let config: Config = read_config(config_path).expect("Failed to read config file");
+
+    let mut parser = Parser::new();
+    let language = unsafe { tree_sitter_go() };
+    parser.set_language(language).expect("Error loading Go grammar");
+
+    process_directory(&parser, &config, Path::new(code_path));
+}
+
+fn read_config<P: AsRef<Path>>(path: P) -> Result<Config, Box<dyn std::error::Error>> {
+    let file = fs::File::open(path)?;
+    let config: Config = serde_yaml::from_reader(file)?;
+    Ok(config)
+}
+
+fn process_directory(parser: &Parser, config: &Config, path: &Path) {
+    if path.is_dir() {
+        for entry in fs::read_dir(path).expect("Failed to read directory") {
+            let entry = entry.expect("Failed to read directory entry");
+            let path = entry.path();
+            if path.is_dir() {
+                process_directory(parser, config, &path);
+            } else if path.extension().and_then(|s| s.to_str()) == Some("go") {
+                process_file(parser, config, &path);
+            }
+        }
+    }
+}
+
+fn process_file(parser: &Parser, config: &Config, path: &Path) {
+    let source_code = fs::read_to_string(path).expect("Failed to read file");
+    let tree = parser.parse(&source_code, None).expect("Failed to parse file");
+
+    let mut cursor = tree.walk();
+    let mut edits = Vec::new();
+
+    loop {
+        let node = cursor.node();
+        if node.is_named() && node.kind() == "import_spec" {
+            let module_name = node.utf8_text(source_code.as_bytes()).expect("Failed to get text");
+            if module_name.contains(&config.replace.go_module.from) {
+                let new_module_name = module_name.replace(&config.replace.go_module.from, &config.replace.go_module.to);
+                edits.push((node.start_byte(), node.end_byte(), new_module_name));
+            }
+        }
+
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+    }
+
+    let mut new_source_code = source_code.clone();
+    for (start, end, replacement) in edits.iter().rev() {
+        new_source_code.replace_range(*start..*end, replacement);
+    }
+
+    fs::write(path, new_source_code).expect("Failed to write file");
+}

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -1,0 +1,56 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn test_go_module_dependency_update() {
+    // Set up test directory and files
+    let test_dir = Path::new("test_data");
+    let go_file_path = test_dir.join("main.go");
+    let config_file_path = test_dir.join("config.yaml");
+
+    fs::create_dir_all(test_dir).expect("Failed to create test directory");
+
+    // Write test Go file
+    let go_file_content = r#"
+        package main
+
+        import (
+            "fmt"
+            "some.module"
+        )
+
+        func main() {
+            fmt.Println("Hello, world!")
+        }
+    "#;
+    fs::write(&go_file_path, go_file_content).expect("Failed to write test Go file");
+
+    // Write test config file
+    let config_file_content = r#"
+        replace:
+            go-module:
+                from: some.module
+                to: another.module
+    "#;
+    fs::write(&config_file_path, config_file_content).expect("Failed to write test config file");
+
+    // Run the CLI tool
+    let output = Command::new("./target/release/cli")
+        .arg("--config")
+        .arg(config_file_path.to_str().unwrap())
+        .arg("--path")
+        .arg(test_dir.to_str().unwrap())
+        .output()
+        .expect("Failed to execute CLI tool");
+
+    assert!(output.status.success());
+
+    // Verify the Go file has been updated
+    let updated_go_file_content = fs::read_to_string(&go_file_path).expect("Failed to read updated Go file");
+    assert!(updated_go_file_content.contains("another.module"));
+    assert!(!updated_go_file_content.contains("some.module"));
+
+    // Clean up test directory and files
+    fs::remove_dir_all(test_dir).expect("Failed to remove test directory");
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+replace:
+    go-module:
+        from: some.module
+        to: another.module


### PR DESCRIPTION
Related to #1

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/grahambrooks/colab/pull/2?shareId=8b7805f1-7672-4dee-8526-3345cfb4f903).